### PR TITLE
Add 'kmod' for build external kernel modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
        apt-transport-https ca-certificates curl lsb-release \
        rsync python-pystache python-mako vim python-six \
        software-properties-common cpio python3-pip ninja-build \
-       cutils cmake pkg-config xorriso mtools libjson-c-dev
+       cutils cmake pkg-config xorriso mtools libjson-c-dev kmod
 
 
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM ubuntu:18.04
 
-ENV DEBIAN_FRONTEND noninteractive
-
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk git ccache automake \
+    DEBIAN_FRONTEND=noninteractive \
+       apt-get install -y openjdk-8-jdk git ccache automake \
        lzop bison gperf build-essential zip curl \
        zlib1g-dev g++-multilib python3-networkx \
        libxml2-utils bzip2 libbz2-dev libbz2-1.0 \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Celadon Build Environment provides all the necessary packages and environment to
 ## Features
 1. This provides developer a clean build environment that he/she can readily use in their existing environment.
 2. This ensures that developer does not have to make any upgrades or changes in the host environment and hence developer can try celadon building without any changes to host environment.
-3. This provides an easy mechanism to track any changes with respect to celadon build environment and ensures that all developers are using the same envrionment while building celadon. This makes it easier for everyone to debug issues occurring in developer environment. 
+3. This provides an easy mechanism to track any changes with respect to celadon build environment and ensures that all developers are using the same envrionment while building celadon. This makes it easier for everyone to debug issues occurring in developer environment.
 
 ## How To Use
 
-Celadon build environment provides a Dockerfile which contains all the required packages. Hence a developer is expected to build a docker container using the Dockerfile and then use the same for building Celadon. 
+Celadon build environment provides a Dockerfile which contains all the required packages. Hence a developer is expected to build a docker container using the Dockerfile and then use the same for building Celadon.
 
 ### Prerequisite to build celadon-build-environment
 1. Any GNU/Linux based Operating System as Host OS
@@ -24,19 +24,11 @@ To get started, we expect the developer to have synced the latest Dockerfile by 
 ### Step 2: Build docker image
 User can now build the docker image. Please note that this might take sometime as the commands tries to install various package dependencies to create the docker image.
 
-`docker build celadon-build-environment`
-
-Once completed, the output should display the ID of the image generated. Please copy the same and replace below where `<ID>` is mentioned.
-
-### Step 3: Tag docker image
-
-Please tag the docker image generated in Step 2 by running the following command:
-
-`docker tag <ID> celadon-build-environment:latest`
+`docker build --tag celadon-build-environment:latest celadon-build-environment`
 
 Please note `celadon-build-environment:latest` is now generated and can be used to run as a container to get an environment to download and build Celadon.
 
-### Step 4: Create workspace directory in HOST OS
+### Step 3: Create workspace directory in HOST OS
 Before running the docker image, `celadon-build-environment:latest` it is important to create a workspace directory in HOST OS, so that the codebase synced does not get deleted if the container is stopped and can be used for future purposes.
 
 For the same, please create a directory in your local hard disk and set its full path to the environment variable WORKSPACE.
@@ -47,7 +39,7 @@ Since WORKSPACE will be used by local user inside the container image, it is imp
 
 `chmod -R 777 $WORKSPACE`
 
-### Step 5: Run celadon-build-environment along with volume mount of WORKSPACE
+### Step 4: Run celadon-build-environment along with volume mount of WORKSPACE
 
 We have the container image, `celadon-build-environment:latest` and workspace directory `$WORKSPACE` ready. Let us use both of them to start the container.
 
@@ -57,7 +49,7 @@ This should give you a BASH prompt as `celadon` user. Change directory to `data`
 
 `cd /data`
 
-### Step 6: Init and Sync the Celadon codebase
+### Step 5: Init and Sync the Celadon codebase
 
 You can now follow the steps to get the Celadon codebase and build it as mentioned in the [official Celadon documentation given here](https://docs.01.org/celadon/getting-started/build-source.html#build-c-in-vm-with-android-12).
 


### PR DESCRIPTION
to avoid the below message, and need **kmod** to generation modules.dep

```
  INSTALL sound/usb/hiface/snd-usb-hiface.ko
  DEPMOD  5.4.150-g043148f5cf6a
Warning: 'make modules_install' requires depmod. Please install it.
This is probably in the kmod package.
make[1]: Leaving directory '/out/target/product/caas/obj/kernel'
```